### PR TITLE
Use cmake to find SDL dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(catkin REQUIRED COMPONENTS cv_bridge roscpp rospy dynamic_reconfigu
 
 ## System dependencies are found with CMake's conventions
 find_package(Boost REQUIRED COMPONENTS thread signals program_options)
-
+find_package(SDL2 REQUIRED)
 
 
 find_package(OpenCV REQUIRED)
@@ -103,7 +103,7 @@ catkin_package(
 ## Your package locations should be listed before other locations
 include_directories(include
   ${catkin_INCLUDE_DIRS}
-  /usr/include/SDL
+  ${SDL2_INCLUDE_DIRS}
   ./
   )
 
@@ -113,7 +113,7 @@ add_library(tuw_uvc
   src/luvcview/utils.c
   src/luvcview/v4l2uvc.c
 )
-target_link_libraries(tuw_uvc m SDL v4l2)
+target_link_libraries(tuw_uvc m ${SDL2_LIBRARIES} v4l2)
 
 add_library(tuw_uvc_ros
   src/tuw_uvc/uvc.cpp 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # tuw_uvc
 ## Dependencies
-sudo apt-get install libv4l-dev
-sudo apt-get install libsdl2-dev
+```
+$ sudo apt-get install libv4l-dev
+$ sudo apt-get install libsdl2-dev
+```


### PR DESCRIPTION
On newer Ubuntu versions the path is /usr/include/SDL2 instead of /usr/include/SDL so building this package fails.
With the dist dev package of sdl2 we also get a config.cmake file allowing us to resolve the paths automatically so better use that instead.
```
libsdl2-dev:
  Installed: 2.0.8+dfsg1-1ubuntu1.18.04.4
```